### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2](https://github.com/arlyon/bluenoise-rs/compare/v0.2.1...v0.2.2) - 2025-10-26
+
+### Other
+
+- Updated dependencies and rust edition
+- add release-plz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "bluenoise"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "criterion",
  "glam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "bluenoise"
 readme = "readme.md"
 repository = "https://github.com/arlyon/bluenoise-rs"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 glam = "0.30.8"


### PR DESCRIPTION



## 🤖 New release

* `bluenoise`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/arlyon/bluenoise-rs/compare/v0.2.1...v0.2.2) - 2025-10-26

### Other

- Updated dependencies and rust edition
- add release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).